### PR TITLE
Fixed trailing slash issue with shiro ext wildcard permission

### DIFF
--- a/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/permissions/ExtWildcardPermission.java
+++ b/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/permissions/ExtWildcardPermission.java
@@ -306,7 +306,17 @@ public final class ExtWildcardPermission
                 String partString = part.iterator().next();
                 String otherPartString = otherPart.iterator().next();
                 if (otherPartString.equals(partString)) return true;
-                if (otherPartString.startsWith(partString + "/")) return true;
+                
+                // This check implements directory semantics. If partString ends with 
+                // a "/", then we are implicitly enforcing directory semantics.
+                // If partString does not end with a "/", then we insert a trailing
+                // "/" to enforce directory semantics and avoid false capture.
+                // EX: We do not want "/home/bud" to return true for both "/home/bud"
+                // and "/home/bud2".
+                if (partString.endsWith("/")) {
+                	if (otherPartString.startsWith(partString)) return true;
+                }
+                else if (otherPartString.startsWith(partString + "/")) return true;
                 break;
         }
         

--- a/tapis-securitylib/src/test/java/edu/utexas/tacc/tapis/security/authz/permissions/ShiroExtPermissionTest.java
+++ b/tapis-securitylib/src/test/java/edu/utexas/tacc/tapis/security/authz/permissions/ShiroExtPermissionTest.java
@@ -4,15 +4,15 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /** Basic sanity check of Shiro Wildcard permission checking.
- * 
+ *  altered jun28 by jgaither
  * @author rcardone
  */
 @Test(groups= {"unit"})
 public class ShiroExtPermissionTest 
 {
-    /* ---------------------------------------------------------------------- */
-    /* tenantTest:                                                            */
-    /* ---------------------------------------------------------------------- */
+	/* ------------------------------------------------------------------------------------------------------------------------------ */
+    /* tenantTest:                                                                                                                    */
+    /* ------------------------------------------------------------------------------------------------------------------------------ */
     @Test(enabled=true)
     public void tenantTest()
     {
@@ -51,19 +51,54 @@ public class ShiroExtPermissionTest
       
       implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/:xx"));
       Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/:xx");
+      
+      
+      /* ---------------------------------------------------------------------- */
+      /* New True Tenant Tests with trailing slashes (read):                    */
+      /* ---------------------------------------------------------------------- */
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/myfile/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/myfile/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/myfile/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/myfile/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my:file/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my:file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my,file/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my,file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my*file/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my*file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/*,:/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/*,:/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/:xx/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/:xx/");
+      
+      
     }
 
-    /* ---------------------------------------------------------------------- */
-    /* pathTest:                                                              */
-    /* ---------------------------------------------------------------------- */
+    /* ------------------------------------------------------------------------------------------------------------------------------ */
+    /* pathTest:                                                                                                                      */
+    /* ------------------------------------------------------------------------------------------------------------------------------ */
     @Test(enabled=true)
     public void pathTest()
     {
+      // wcPerm being checked must be a prefix of the string being passed in. Absence of a trailing slash marks access to the directory
+      // as well as sub-directories. Presence of a trailing slash only gives access to the resources under the directory, not the 
+      // directory itself
+    	
       // The required permission spec.
       ExtWildcardPermission wcPerm = new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud");
       
-      boolean implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud"));
-      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud");
+      boolean implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/");
       
       implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/"));
       Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/");
@@ -89,6 +124,42 @@ public class ShiroExtPermissionTest
       implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/:xx"));
       Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/:xx");
       
+      /* ---------------------------------------------------------------------- */
+      /* New True Path Tests with trailing slashes:                             */
+      /* ---------------------------------------------------------------------- */
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/myfile/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/myfile/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/myfile/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/myfile/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir,myfile"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir,myfile");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir,myfile/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir,myfile/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my:file/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my:file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my,file/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my,file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my*file/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my*file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/*,:/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/*,:/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/:xx/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/:xx/");
+      
+      
+      /* ---------------------------------------------------------------------- */
+      /* Existing False Path Tests with trailing slashes:                       */
+      /* ---------------------------------------------------------------------- */
+      
       implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org"));
       Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org");
       
@@ -107,11 +178,199 @@ public class ShiroExtPermissionTest
       implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:*:/home/bud/mydir/myfile"));
       Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:read:*:/home/bud/mydir/myfile");
       
+      
+      /* ---------------------------------------------------------------------- */
+      /* New False Path Tests with trailing slashes for write                   */
+      /* ---------------------------------------------------------------------- */
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/myfile/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/myfile/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/mydir,myfile"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/mydir,myfile");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/mydir,myfile/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/mydir,myfile/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/my:file"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/my:file");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/my:file/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/my:file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/my,file"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/my,file");
+
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/my,file/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/my,file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/my*file"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/my*file");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/my*file/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/my*file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/*,:"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/*,:");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/*,:/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/*,:/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/:xx"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/:xx");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/:xx/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/:xx/");
+   
+    }
+    
+    
+    /* ------------------------------------------------------------------------------------------------------------------------------ */
+    /* pathTest:                                                                                                                      */
+    /* ------------------------------------------------------------------------------------------------------------------------------ */
+    @Test(enabled=true)
+    public void pathTestWithSlash()
+    {
+      // wcPerm being checked must be a prefix of the string being passed in. Absence of a trailing slash marks access to the directory
+      // as well as sub-directories. Presence of a trailing slash only gives access to the resources under the directory, not the 
+      // directory itself
+    	
+      // The required permission spec.
+      ExtWildcardPermission wcPerm = new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/");
+      
+      boolean implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/myfile"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/myfile");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/myfile"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/myfile");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my:file"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my:file");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my,file"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my,file");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my*file"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my*file");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/*,:"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/*,:");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/:xx"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/:xx");
+      
+      /* ---------------------------------------------------------------------- */
+      /* New True Path Tests with trailing slashes:                             */
+      /* ---------------------------------------------------------------------- */
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/myfile/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/myfile/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/myfile/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/myfile/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir,myfile"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir,myfile");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir,myfile/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir,myfile/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my:file/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my:file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my,file/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my,file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my*file/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my*file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/*,:/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/*,:/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/:xx/"));
+      Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/:xx/");
+      
+      
+      /* ---------------------------------------------------------------------- */
+      /* Existing False Path Tests with trailing slashes:                       */
+      /* ---------------------------------------------------------------------- */
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:read");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:read:stampede2");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:read:stampede2:/home/bud");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud2/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:read:stampede2:/home/bud2/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read,write:stampede2:/home/bud/myfile"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:read,write:stampede2:/home/bud/myfile");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/myfile"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/myfile");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:*:/home/bud/mydir/myfile"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:read:*:/home/bud/mydir/myfile");
+      
+      
+      /* ---------------------------------------------------------------------- */
+      /* New False Path Tests with trailing slashes for write                   */
+      /* ---------------------------------------------------------------------- */
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/myfile/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/myfile/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/mydir,myfile"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/mydir,myfile");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/mydir,myfile/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/mydir,myfile/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/my:file"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/my:file");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/my:file/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/my:file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/my,file"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/my,file");
+
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/my,file/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/my,file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/my*file"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/my*file");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/my*file/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/my*file/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/*,:"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/*,:");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/*,:/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/*,:/");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/:xx"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/:xx");
+      
+      implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:write:stampede2:/home/bud/:xx/"));
+      Assert.assertFalse(implies, "Expected " + wcPerm + " to NOT imply files:iplantc.org:write:stampede2:/home/bud/:xx/");
+   
     }
 
-    /* ---------------------------------------------------------------------- */
-    /* validPermTest:                                                         */
-    /* ---------------------------------------------------------------------- */
+    /* ------------------------------------------------------------------------------------------------------------------------------ */
+    /* validPermTest:                                                                                                                 */
+    /* ------------------------------------------------------------------------------------------------------------------------------ */
     @Test(enabled=true)
     public void validPermTest()
     {
@@ -142,11 +401,52 @@ public class ShiroExtPermissionTest
         
         implies = wcPerm.implies(new ExtWildcardPermission("*"));
         Assert.assertFalse(implies, "Expected " + wcPerm + " to not imply *");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("*,:/"));
+        Assert.assertFalse(implies, "Expected " + wcPerm + " to not imply *,:/");
+        
+        
+        /* ---------------------------------------------------------------------- */
+        /* New True validPermTest with trailing slashes                           */
+        /* ---------------------------------------------------------------------- */
+        
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:b/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:b/");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:z/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:z/");
+        
+        // FAILS ----------------------------------------------------------------
+        //
+        //implies = wcPerm.implies(new ExtWildcardPermission("files/"));
+        //Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files/");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:/");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:*/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:*/");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:b,*/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:b,*/");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:c,*/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:c,*/");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:*:d:e:f/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:*:d:e:f/");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("*/"));
+        Assert.assertFalse(implies, "Expected " + wcPerm + " to not imply */");
+        
+        
+        
     }
     
-    /* ---------------------------------------------------------------------- */
-    /* allowAllTest:                                                          */
-    /* ---------------------------------------------------------------------- */
+    /* ------------------------------------------------------------------------------------------------------------------------------ */
+    /* allowAllTest:                                                                                                                 */
+    /* ------------------------------------------------------------------------------------------------------------------------------ */
     @Test(enabled=true)
     public void allowAllTest()
     {
@@ -155,5 +455,51 @@ public class ShiroExtPermissionTest
         
         boolean implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/myfile"));
         Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/myfile");
+
+        /* ---------------------------------------------------------------------- */
+        /* New True allowAllTest without trailing slashes (read)                  */
+        /* ---------------------------------------------------------------------- */     
+       
+        implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/myfile"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/myfile");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my:file"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my:file");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my,file"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my,file");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my*file"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my*file");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/*,:"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/*,:");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/:xx"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/:xx");
+        
+        /* ---------------------------------------------------------------------- */
+        /* New True allowAllTest with trailing slashes (read)                     */
+        /* ---------------------------------------------------------------------- */
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/myfile/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/myfile/");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my:file/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my:file/");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my,file/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my,file/");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/mydir/my*file/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/mydir/my*file/");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/*,:/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/*,:/");
+        
+        implies = wcPerm.implies(new ExtWildcardPermission("files:iplantc.org:read:stampede2:/home/bud/:xx/"));
+        Assert.assertTrue(implies, "Expected " + wcPerm + " to imply files:iplantc.org:read:stampede2:/home/bud/:xx/");
+        
+        
     }
 }


### PR DESCRIPTION
Here are the two changed files for ext wildcard permissions within tapis-securitylib